### PR TITLE
XDG_CACHE_HOME isn't always set (Segmentation fault)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PREFIX = /usr/local
 LIBS = -lgit2 -lcurl -ljson-c
 FLAGS = ${LIBS}
 PROG = aureate
+XDG_CACHE_HOME ?= ${HOME}/.cache
 
 all:
 	cc ${PROG}.c ${FLAGS} -o ${PROG}

--- a/aureate.c
+++ b/aureate.c
@@ -88,6 +88,8 @@ void search(const char *pkg) {
 int download(int argc, char *argv[]) {
 	//define vars
 	const char* syscache = getenv("XDG_CACHE_HOME");
+	if (syscache == NULL)
+		syscache = "~/.cache/";
 	for (int i = 2; i < argc; i++) {
 		const char* pkg = argv[i];
 	


### PR DESCRIPTION
On some machines (including mine), `XDG_CACHE_HOME` is not set, and because of this, the program crashes. It is better to set a fallback cache directory (by default `~/.cache`) for this.