### PR TITLE
The `uninstall` recipe of the `Makefile` does not remove the man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 
 uninstall:
 	rm -f ${PREFIX}/bin/${PROG}
+	rm -f ${PREFIX}/share/man/man1/${PROG}.1
 
 clean:
 	rm -rf ${XDG_CACHE_HOME}/${PROG}


### PR DESCRIPTION
Added command to the `uninstall` recipe of the `Makefile` to remove the installed man page.