### PR TITLE
make running `make install` first not break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all:
 debug:
 	clang ${PROG}.c -Wall -Werror -fsanitize=undefined,address ${FLAGS} -o ${PROG}
 
-install:
+install: all
 	install -Dm755 ./${PROG} ${PREFIX}/bin/${PROG}
 	install -Dm644 ./${PROG}.1 ${PREFIX}/share/man/man1/${PROG}.1
 


### PR DESCRIPTION
if you run `make install` before `make` it tries to install a non existent binary file, this forces it to compile the binary file first

this happens with both gmake and bmake.